### PR TITLE
Add GraphQL query support for data models

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -169,7 +170,7 @@ func main() {
 		nil,
 		nil,
 		nil,
-		100,
+		10,
 	)
 	if err != nil {
 		fmt.Println("Error:", err)
@@ -224,5 +225,61 @@ func main() {
 
 		fmt.Println()
 	}
+
+	// GraphQL Query Example
+	fmt.Println("\n=== GraphQL Query Example ===")
+	graphQLQuery := `query MyQuery($nItems: Int) {
+  listCogniteUnit(filter: {space: {eq: "cdf_cdm_units"}}, first: $nItems) {
+    items {
+      tags
+      symbol
+      space
+      source
+      sourceReference
+      quantity
+      name
+      lastUpdatedTime
+      externalId
+      description
+      createdTime
+      aliases
+    }
+  }
+}`
+
+	variables := map[string]interface{}{
+		"nItems": 10,
+	}
+
+	graphQLResponse, err := client.DataModeling.GraphQLQuery(
+		"cdf_cdm",
+		"CogniteCore",
+		"v1",
+		graphQLQuery,
+		variables,
+	)
+	if err != nil {
+		fmt.Println("GraphQL query error:", err)
+		return
+	}
+
+	// Check for GraphQL errors
+	if len(graphQLResponse.Errors) > 0 {
+		fmt.Println("GraphQL errors:")
+		for _, gqlErr := range graphQLResponse.Errors {
+			fmt.Printf("  - %s\n", gqlErr.Message)
+		}
+		return
+	}
+
+	// Print the response as JSON
+	fmt.Println("GraphQL query successful!")
+	fmt.Println("Response data:")
+	jsonData, err := json.MarshalIndent(graphQLResponse.Data, "", "  ")
+	if err != nil {
+		fmt.Println("Error marshaling response to JSON:", err)
+		return
+	}
+	fmt.Println(string(jsonData))
 
 }

--- a/pkg/dto/data_models.go
+++ b/pkg/dto/data_models.go
@@ -55,3 +55,19 @@ type SearchSort struct {
 	Property  string  `json:"property"`
 	Direction *string `json:"direction,omitempty"`
 }
+
+type GraphQLRequest struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables,omitempty"`
+}
+
+type GraphQLResponse struct {
+	Data   map[string]interface{} `json:"data,omitempty"`
+	Errors []GraphQLError         `json:"errors,omitempty"`
+}
+
+type GraphQLError struct {
+	Message    string                 `json:"message"`
+	Path       []interface{}          `json:"path,omitempty"`
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Adds GraphQL query functionality to the Go SDK following the Python SDK pattern
- Implements proper request/response handling with error support
- Includes example usage demonstrating the new functionality

## Changes
1. **Added DTOs** (`pkg/dto/data_models.go`):
   - `GraphQLRequest`: Handles GraphQL query and variables
   - `GraphQLResponse`: Handles response data and errors
   - `GraphQLError`: Represents GraphQL-specific errors

2. **Implemented API method** (`pkg/api/data_models.go`):
   - `GraphQLQuery()`: Executes GraphQL queries against data models
   - Parameters: space, externalId, version, query, and variables
   - Constructs proper endpoint URL: `/api/v1/projects/{project}/userapis/spaces/{space}/datamodels/{externalId}/versions/{version}/graphql`
   - Handles both HTTP and GraphQL errors

3. **Added example** (`main.go`):
   - Demonstrates querying CogniteCore v1 data model
   - Uses the provided query to list Cognite units
   - Shows proper error handling and pretty-printed JSON output

## Test plan
- [x] Run `go run main.go` to verify the GraphQL query executes successfully
- [x] Verify the response is properly formatted as JSON
- [x] Test error handling with invalid queries or parameters
- [ ] Add unit tests (planned for future PR)

🤖 Generated with [Claude Code](https://claude.ai/code)