### PR TITLE
fix: use shell variable in heredoc to avoid YAML parsing error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,8 @@ jobs:
           mv artifacts/*/* .
           
           # Create release notes file
-          cat > release-notes.md << 'EOF'
-Release ${{ github.ref_name }} of poc-requests-go - A Go client library for Cognite Data Fusion (CDF) APIs
+          cat > release-notes.md << EOF
+Release ${GITHUB_REF_NAME} of poc-requests-go - A Go client library for Cognite Data Fusion (CDF) APIs
 
 ## Features
 - **Time Series API** support:


### PR DESCRIPTION
## Summary
- Fix YAML parsing error on line 83 of release workflow
- Replace GitHub Actions expression `${{ github.ref_name }}` with shell variable `${GITHUB_REF_NAME}` inside heredoc

## Context
GitHub Actions expressions inside heredocs cause YAML parsing errors. Using shell environment variables instead resolves this issue.

## Test plan
- [ ] Workflow will be tested when we recreate the release tag after merging

🤖 Generated with [Claude Code](https://claude.ai/code)